### PR TITLE
Don't include unnecessary headers in mbelib.h

### DIFF
--- a/ambe3600x2250.c
+++ b/ambe3600x2250.c
@@ -16,8 +16,11 @@
  */
 
 #include <stdlib.h>
-#include <mbelib.h>
-#include <ambe3600x2250_const.h>
+#include <stdio.h>
+#include <math.h>
+
+#include "mbelib.h"
+#include "ambe3600x2250_const.h"
 
 void
 mbe_dumpAmbe2250Data (char *ambe_d)

--- a/imbe7100x4400.c
+++ b/imbe7100x4400.c
@@ -16,7 +16,10 @@
  */
 
 #include <stdlib.h>
-#include <mbelib.h>
+#include <stdio.h>
+#include <math.h>
+
+#include "mbelib.h"
 
 void
 mbe_dumpImbe7100x4400Data (char *imbe_d)

--- a/imbe7200x4400.c
+++ b/imbe7200x4400.c
@@ -16,8 +16,11 @@
  */
 
 #include <stdlib.h>
-#include <mbelib.h>
-#include <imbe7200x4400_const.h>
+#include <stdio.h>
+#include <math.h>
+
+#include "mbelib.h"
+#include "imbe7200x4400_const.h"
 
 void
 mbe_dumpImbe4400Data (char *imbe_d)

--- a/mbelib.c
+++ b/mbelib.c
@@ -16,6 +16,9 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+
 #include "mbelib.h"
 #include "mbelib_const.h"
 

--- a/mbelib.h
+++ b/mbelib.h
@@ -20,10 +20,6 @@
 
 #define MBELIB_VERSION "1.2.5"
 
-#include "config.h"
-#include <stdio.h>
-#include <math.h>
-
 struct mbe_parameters
 {
   float w0;


### PR DESCRIPTION
The additional headers included in mbelib.h cause issues when trying to compile programs that don't have or need these headers. None of them are necessary for mbelib.h.

This is also a more general header cleanup (mainly switching to the standard <> vs. "" for installed vs local headers).
