### PR TITLE
Rename ambe3600x2250 to ambe3600x2450 to correctly reflect the codec type

### DIFF
--- a/ambe3600x2450.c
+++ b/ambe3600x2450.c
@@ -20,10 +20,10 @@
 #include <math.h>
 
 #include "mbelib.h"
-#include "ambe3600x2250_const.h"
+#include "ambe3600x2450_const.h"
 
 void
-mbe_dumpAmbe2250Data (char *ambe_d)
+mbe_dumpAmbe2450Data (char *ambe_d)
 {
 
   int i;
@@ -39,7 +39,7 @@ mbe_dumpAmbe2250Data (char *ambe_d)
 }
 
 void
-mbe_dumpAmbe3600x2250Frame (char ambe_fr[4][24])
+mbe_dumpAmbe3600x2450Frame (char ambe_fr[4][24])
 {
 
   int j;
@@ -75,7 +75,7 @@ mbe_dumpAmbe3600x2250Frame (char ambe_fr[4][24])
 }
 
 int
-mbe_eccAmbe3600x2250C0 (char ambe_fr[4][24])
+mbe_eccAmbe3600x2450C0 (char ambe_fr[4][24])
 {
 
   int j, errs;
@@ -97,7 +97,7 @@ mbe_eccAmbe3600x2250C0 (char ambe_fr[4][24])
 }
 
 int
-mbe_eccAmbe3600x2250Data (char ambe_fr[4][24], char *ambe_d)
+mbe_eccAmbe3600x2450Data (char ambe_fr[4][24], char *ambe_d)
 {
 
   int j, errs;
@@ -141,7 +141,7 @@ mbe_eccAmbe3600x2250Data (char ambe_fr[4][24], char *ambe_d)
 }
 
 int
-mbe_decodeAmbe2250Parms (char *ambe_d, mbe_parms * cur_mp, mbe_parms * prev_mp)
+mbe_decodeAmbe2450Parms (char *ambe_d, mbe_parms * cur_mp, mbe_parms * prev_mp)
 {
 
   int ji, i, j, k, l, L, L9, m, am, ak;
@@ -219,7 +219,7 @@ mbe_decodeAmbe2250Parms (char *ambe_d, mbe_parms * cur_mp, mbe_parms * prev_mp)
   // decode L
   if (silence == 0)
     {
-      // L from specification document 
+      // L from specification document
       // lookup L in tabl3
       L = AmbeLtable[b0];
       // L formula from patent filings
@@ -554,7 +554,7 @@ mbe_decodeAmbe2250Parms (char *ambe_d, mbe_parms * cur_mp, mbe_parms * prev_mp)
 }
 
 void
-mbe_demodulateAmbe3600x2250Data (char ambe_fr[4][24])
+mbe_demodulateAmbe3600x2450Data (char ambe_fr[4][24])
 {
   int i, j, k;
   unsigned short pr[115];
@@ -586,7 +586,7 @@ mbe_demodulateAmbe3600x2250Data (char ambe_fr[4][24])
 }
 
 void
-mbe_processAmbe2250Dataf (float *aout_buf, int *errs, int *errs2, char *err_str, char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality)
+mbe_processAmbe2450Dataf (float *aout_buf, int *errs, int *errs2, char *err_str, char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality)
 {
 
   int i, bad;
@@ -597,7 +597,7 @@ mbe_processAmbe2250Dataf (float *aout_buf, int *errs, int *errs2, char *err_str,
       err_str++;
     }
 
-  bad = mbe_decodeAmbe2250Parms (ambe_d, cur_mp, prev_mp);
+  bad = mbe_decodeAmbe2450Parms (ambe_d, cur_mp, prev_mp);
   if (bad == 2)
     {
       // Erasure frame
@@ -650,33 +650,33 @@ mbe_processAmbe2250Dataf (float *aout_buf, int *errs, int *errs2, char *err_str,
 }
 
 void
-mbe_processAmbe2250Data (short *aout_buf, int *errs, int *errs2, char *err_str, char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality)
+mbe_processAmbe2450Data (short *aout_buf, int *errs, int *errs2, char *err_str, char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality)
 {
   float float_buf[160];
 
-  mbe_processAmbe2250Dataf (float_buf, errs, errs2, err_str, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+  mbe_processAmbe2450Dataf (float_buf, errs, errs2, err_str, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
   mbe_floattoshort (float_buf, aout_buf);
 }
 
 void
-mbe_processAmbe3600x2250Framef (float *aout_buf, int *errs, int *errs2, char *err_str, char ambe_fr[4][24], char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality)
+mbe_processAmbe3600x2450Framef (float *aout_buf, int *errs, int *errs2, char *err_str, char ambe_fr[4][24], char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality)
 {
 
   *errs = 0;
   *errs2 = 0;
-  *errs = mbe_eccAmbe3600x2250C0 (ambe_fr);
-  mbe_demodulateAmbe3600x2250Data (ambe_fr);
+  *errs = mbe_eccAmbe3600x2450C0 (ambe_fr);
+  mbe_demodulateAmbe3600x2450Data (ambe_fr);
   *errs2 = *errs;
-  *errs2 += mbe_eccAmbe3600x2250Data (ambe_fr, ambe_d);
+  *errs2 += mbe_eccAmbe3600x2450Data (ambe_fr, ambe_d);
 
-  mbe_processAmbe2250Dataf (aout_buf, errs, errs2, err_str, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+  mbe_processAmbe2450Dataf (aout_buf, errs, errs2, err_str, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
 }
 
 void
-mbe_processAmbe3600x2250Frame (short *aout_buf, int *errs, int *errs2, char *err_str, char ambe_fr[4][24], char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality)
+mbe_processAmbe3600x2450Frame (short *aout_buf, int *errs, int *errs2, char *err_str, char ambe_fr[4][24], char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality)
 {
   float float_buf[160];
 
-  mbe_processAmbe3600x2250Framef (float_buf, errs, errs2, err_str, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
+  mbe_processAmbe3600x2450Framef (float_buf, errs, errs2, err_str, ambe_fr, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
   mbe_floattoshort (float_buf, aout_buf);
 }

--- a/ambe3600x2450_const.h
+++ b/ambe3600x2450_const.h
@@ -15,11 +15,11 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef _AMBE3600x2250_CONST_H
-#define _AMBE3600x2250_CONST_H
+#ifndef _AMBE3600x2450_CONST_H
+#define _AMBE3600x2450_CONST_H
 
 /*
- * Fundamental Frequency Quanitization Table 
+ * Fundamental Frequency Quanitization Table
  */
 
 const float AmbeW0table[120] = {
@@ -968,4 +968,4 @@ const float AmbeHOCb8[8][4] = {
   {0.096949, -0.096400, 0.083194, 0.049306}
 };
 
-#endif
+#endif /* _AMBE3600x2450_CONST_H */

--- a/mbelib.h
+++ b/mbelib.h
@@ -46,16 +46,16 @@ int mbe_hamming1511 (char *in, char *out);
 int mbe_7100x4400hamming1511 (char *in, char *out);
 
 /*
- * Prototypes from ambe3600x2250.c
+ * Prototypes from ambe3600x2450.c
  */
-int mbe_eccAmbe3600x2250C0 (char ambe_fr[4][24]);
-int mbe_eccAmbe3600x2250Data (char ambe_fr[4][24], char *ambe_d);
-int mbe_decodeAmbe2250Parms (char *ambe_d, mbe_parms * cur_mp, mbe_parms * prev_mp);
-void mbe_demodulateAmbe3600x2250Data (char ambe_fr[4][24]);
-void mbe_processAmbe2250Dataf (float *aout_buf, int *errs, int *errs2, char *err_str, char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality);
-void mbe_processAmbe2250Data (short *aout_buf, int *errs, int *errs2, char *err_str, char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality);
-void mbe_processAmbe3600x2250Framef (float *aout_buf, int *errs, int *errs2, char *err_str, char ambe_fr[4][24], char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality);
-void mbe_processAmbe3600x2250Frame (short *aout_buf, int *errs, int *errs2, char *err_str, char ambe_fr[4][24], char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality);
+int mbe_eccAmbe3600x2450C0 (char ambe_fr[4][24]);
+int mbe_eccAmbe3600x2450Data (char ambe_fr[4][24], char *ambe_d);
+int mbe_decodeAmbe2450Parms (char *ambe_d, mbe_parms * cur_mp, mbe_parms * prev_mp);
+void mbe_demodulateAmbe3600x2450Data (char ambe_fr[4][24]);
+void mbe_processAmbe2450Dataf (float *aout_buf, int *errs, int *errs2, char *err_str, char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality);
+void mbe_processAmbe2450Data (short *aout_buf, int *errs, int *errs2, char *err_str, char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality);
+void mbe_processAmbe3600x2450Framef (float *aout_buf, int *errs, int *errs2, char *err_str, char ambe_fr[4][24], char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality);
+void mbe_processAmbe3600x2450Frame (short *aout_buf, int *errs, int *errs2, char *err_str, char ambe_fr[4][24], char ambe_d[49], mbe_parms * cur_mp, mbe_parms * prev_mp, mbe_parms * prev_mp_enhanced, int uvquality);
 
 /*
  * Prototypes from imbe7200x4400.c


### PR DESCRIPTION
This renames ambe3600x2250 to 3600x2450. This variant of AMBE has 49 speech bits and 23 FEC bits for a total bitrate of 3600bps, therefore 2450bps is used for speech and 1150bps is used for FEC.

This will break dsd; a PR to fix dsd will be submitted shortly.
